### PR TITLE
replace self closing tag with closing tag in docs

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -53,7 +53,7 @@
               <p class="step-explain">And include it in your project</p>
               <pre><code class="hljs javascript">  import Chart from "frappe-charts/dist/frappe-charts.min.esm"</code></pre>
               <p class="step-explain">... or include it directly in your HTML</p>
-              <pre><code class="hljs html">  &lt;script src="https://unpkg.com/frappe-charts@0.0.3/dist/frappe-charts.min.iife.js" &gt;&lt;/script&gt;</code></pre>
+              <pre><code class="hljs html">  &lt;script src="https://unpkg.com/frappe-charts@0.0.3/dist/frappe-charts.min.iife.js"&gt;&lt;/script&gt;</code></pre>
               <p class="step-explain">Make a new Chart</p>
               <pre><code class="hljs html">  &lt!--HTML--&gt;
   &lt;div id="chart"&gt;&lt;/div&gt;</code></pre>

--- a/docs/index.html
+++ b/docs/index.html
@@ -53,7 +53,7 @@
               <p class="step-explain">And include it in your project</p>
               <pre><code class="hljs javascript">  import Chart from "frappe-charts/dist/frappe-charts.min.esm"</code></pre>
               <p class="step-explain">... or include it directly in your HTML</p>
-              <pre><code class="hljs html">  &lt;script src="https://unpkg.com/frappe-charts@0.0.3/dist/frappe-charts.min.iife.js" /&gt;</code></pre>
+              <pre><code class="hljs html">  &lt;script src="https://unpkg.com/frappe-charts@0.0.3/dist/frappe-charts.min.iife.js" &gt;&lt;/script&gt;</code></pre>
               <p class="step-explain">Make a new Chart</p>
               <pre><code class="hljs html">  &lt!--HTML--&gt;
   &lt;div id="chart"&gt;&lt;/div&gt;</code></pre>


### PR DESCRIPTION
######Explanation About What Code Achieves:

I naively copied the <script src="https://unpkg.com/frappe-charts@0.0.3/dist/frappe-charts.min.iife.js"/> from the docs and it silently broke parts of my page as chrome didn't parse some of my javascript. I've updated the docs page with the closing. Also matches https://www.npmjs.com/package/frappe-charts