### PR TITLE
Add alternative CDN

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@
 * ...or include within your HTML
 
   ```html
+    <script src="https://cdn.jsdelivr.net/npm/frappe-charts@0.0.8/dist/frappe-charts.min.iife.js"></script>
+    <!-- or -->
     <script src="https://unpkg.com/frappe-charts@0.0.8/dist/frappe-charts.min.iife.js"></script>
   ```
 


### PR DESCRIPTION
I added a [jsDelivr CDN links](https://www.jsdelivr.com/package/npm/frappe-charts) to your readme as an alternative to unpkg. jsDelivr is the fastest opensource CDN available and built specifically for production usage. It can instantly serve any project from npm with zero config and offers a large network and better reliability.