### PR TITLE
Calculate exponent for intervals based on range between values

### DIFF
--- a/src/js/charts/AxisChart.js
+++ b/src/js/charts/AxisChart.js
@@ -60,7 +60,7 @@ export default class AxisChart extends BaseChart {
 			values = values.concat(this.y_sums);
 		}
 
-		this.y_axis_values = calcIntervals(values, this.type === 'line');
+		this.y_axis_values = calcIntervals(values, this.type === 'line', this.y_axis_exp_based_on_range === true);
 
 		if(!this.y_old_axis_values) {
 			this.y_old_axis_values = this.y_axis_values.slice();

--- a/src/js/charts/LineChart.js
+++ b/src/js/charts/LineChart.js
@@ -21,6 +21,7 @@ export default class LineChart extends AxisChart {
 		this.dot_radius = args.dot_radius || 4;
 		this.heatline = args.heatline;
 		this.type = 'line';
+		this.y_axis_exp_based_on_range = args.y_axis_exp_based_on_range;
 
 		this.setup();
 	}

--- a/src/js/utils/intervals.js
+++ b/src/js/utils/intervals.js
@@ -59,8 +59,17 @@ function getRangeIntervals(max, min=0) {
 	return intervals;
 }
 
-function getIntervals(maxValue, minValue=0) {
-	let [normalMaxValue, exponent] = normalize(maxValue);
+function getIntervals(maxValue, minValue=0, expBasedOnRange=false) {
+	let exponent, normalMaxValue;
+
+	if (expBasedOnRange) {
+		let range = maxValue - minValue;
+		exponent = normalize(range)[1];
+		normalMaxValue = maxValue/Math.pow(10, exponent);
+	} else {
+		[normalMaxValue, exponent] = normalize(maxValue);
+	}
+
 	let normalMinValue = minValue ? minValue/Math.pow(10, exponent): 0;
 
 	// Allow only 7 significant digits
@@ -71,7 +80,7 @@ function getIntervals(maxValue, minValue=0) {
 	return intervals;
 }
 
-export function calcIntervals(values, withMinimum=false) {
+export function calcIntervals(values, withMinimum=false, expBasedOnRange=false) {
 	//*** Where the magic happens ***
 
 	// Calculates best-fit y intervals from given values
@@ -104,7 +113,7 @@ export function calcIntervals(values, withMinimum=false) {
 		if(!withMinimum) {
 			intervals = getIntervals(maxValue);
 		} else {
-			intervals = getIntervals(maxValue, minValue);
+			intervals = getIntervals(maxValue, minValue, expBasedOnRange);
 		}
 	}
 
@@ -144,7 +153,7 @@ export function calcIntervals(values, withMinimum=false) {
 		if(!withMinimum) {
 			intervals = getIntervals(pseudoMaxValue);
 		} else {
-			intervals = getIntervals(pseudoMaxValue, pseudoMinValue);
+			intervals = getIntervals(pseudoMaxValue, pseudoMinValue, expBasedOnRange);
 		}
 
 		intervals = intervals.reverse().map(d => d * (-1));


### PR DESCRIPTION
<!-- Thank you so much for contributing! We're glad to have you onboard :) -->
<!-- Please help us understand you contribution better with these details -->

###### Explanation About What Code Achieves:
<!-- Please explain why this code is necessary / what it does -->
  - Aims to resolve #100 (In some edge cases there was lots of blank space and no meaningful chart)
  - This adds a flag to use the range between the values to calculate the exponent for the interval generation rather than the absolute numbers

###### Screenshots/GIFs:
<!-- As this is mainly a visual lib, please include a screenshot/gif if your contribution modifies on-screen components -->
Before: ![dlvoauth local_admin](https://user-images.githubusercontent.com/17156142/36154195-eaff2656-10d0-11e8-99c9-5f53d90b3f03.png)

After: ![dlvoauth local_admin 1](https://user-images.githubusercontent.com/17156142/36154221-fd5f8232-10d0-11e8-9eb5-e01356f35e9d.png)


###### Steps To Test:
<!-- What would someone do to be able to see the effects of your code? -->
  - Set `y_axis_exp_based_on_range: true` on a line chart

###### TODOs:
<!-- Is there any tests or logic that isn't in the pr that you want the reviewer to know about? -->
  - I didn't commit the compiled files
  - I only modified lines where a `minValue` is passed (-> only Line-charts in general). I figured if it is *0* by default nothing would change by using the range for exponent calculation.
