### PR TITLE
move eslint to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "babel-preset-env": "^1.6.1",
     "babel-preset-latest": "^6.24.1",
     "cssnano": "^3.10.0",
+    "eslint": "^4.18.2",
     "livereload": "^0.6.3",
     "node-sass": "^4.7.2",
     "npm-run-all": "^4.1.1",
@@ -52,8 +53,5 @@
     "rollup-plugin-uglify": "^2.0.1",
     "rollup-plugin-uglify-es": "0.0.1",
     "rollup-watch": "^4.3.1"
-  },
-  "dependencies": {
-    "eslint": "^4.18.2"
   }
 }


### PR DESCRIPTION
###### Explanation About What Code Achieves:
<!-- Please explain why this code is necessary / what it does -->
  - Move eslint to devDependencies as its not an actual requirement to run frappe
  - Prevents wrong version of eslint being installed when using with other projects utilizing eslint

thanks for creating frappe