### PR TITLE
Populate the start date of the chart in the configure function.

### DIFF
--- a/src/js/charts/Heatmap.js
+++ b/src/js/charts/Heatmap.js
@@ -16,9 +16,6 @@ export default class Heatmap extends BaseChart {
 		this.discreteDomains = options.discreteDomains === 0 ? 0 : 1;
 		this.countLabel = options.countLabel || '';
 
-		let today = new Date();
-		this.start = options.start || addDays(today, 365);
-
 		let legendColors = (options.legendColors || []).slice(0, 5);
 		this.legendColors = this.validate_colors(legendColors)
 			? legendColors
@@ -52,9 +49,10 @@ export default class Heatmap extends BaseChart {
 		return valid;
 	}
 
-	configure() {
+	configure(options) {
 		super.configure();
 		this.today = new Date();
+		this.start = options.start;
 
 		if(!this.start) {
 			this.start = new Date();


### PR DESCRIPTION
##### Explanation About What Code Achieves:
<!-- Please explain why this code is necessary / what it does -->
  - The `start` option when constructing a heatmap was being ignored: #133.

##### Screenshots/GIFs:
<!-- As this is mainly a visual lib, please include a screenshot/gif if your contribution modifies on-screen components -->
###### A heat map with no start date. By default, the start date is a year from the current date, so April 7, 2017.
  <img width="913" alt="screen shot 2018-04-07 at 12 34 09 am" src="https://user-images.githubusercontent.com/3110602/38451299-6adbdb8c-39fb-11e8-8730-1a13ccabbfbb.png">

###### A heat map with a start date of the current date - 6 months, so October 7, 2017.
<img width="768" alt="screen shot 2018-04-07 at 12 33 42 am" src="https://user-images.githubusercontent.com/3110602/38451300-6ae89368-39fb-11e8-990e-42c6828af6bc.png">

##### Steps To Test:
<!-- What would someone do to be able to see the effects of your code? -->
1. On current master, observe that the start date is ignored when passed to the heat map.
2. With these changes, pass in a start date, and observe that the chart's start date changes.



##### TODOs:
<!-- Is there any tests or logic that isn't in the pr that you want the reviewer to know about? -->
  - None