### PR TITLE
Fix reduce warning for empty arrays

### DIFF
--- a/src/js/utils/intervals.js
+++ b/src/js/utils/intervals.js
@@ -212,7 +212,7 @@ export function isInRange2D(coord, minCoord, maxCoord) {
 export function getClosestInArray(goal, arr, index = false) {
 	let closest = arr.reduce(function(prev, curr) {
 		return (Math.abs(curr - goal) < Math.abs(prev - goal) ? curr : prev);
-	});
+	}, []);
 
 	return index ? arr.indexOf(closest) : closest;
 }


### PR DESCRIPTION
This fixes an error that gets thrown whenever frappe is fed an empty array for its `datasets` property.

The error reads:
```
Uncaught TypeError: Reduce of empty array with no initial value
    at Array.reduce (<anonymous>)
    at getClosestInArray (frappe-charts.esm.js:2671)
```

###### Steps To Test:
  - Initialise or call update on frappe-charts with `datasets: []`

###### TODOs:
  - Not sure. Are there any tests that should be modified or created to cover this behaviour?
