### PR TITLE
Update docs to show how ESM can be imported

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -271,6 +271,8 @@ redirect_to: "https://frappe.io/charts"
       <pre><code class="hljs console">  npm install frappe-charts</code></pre>
       <p>And include it in your project</p>
       <pre><code class="hljs javascript">  import { Chart } from "frappe-charts"</code></pre>
+      <p>(for ES6+ import the ESModule from the dist folder)</p>
+      <pre><code class="hljs javascript">  import { Chart } from "frappe-charts/dist/frappe-charts.esm.js"</code></pre>
       <p>... or include it directly in your HTML</p>
       <pre><code class="hljs html">  &lt;script src="https://unpkg.com/frappe-charts@1.1.0"&gt;&lt;/script&gt;</code></pre>
       <p>Use as:</p>


### PR DESCRIPTION
Not sure why, but importing the Frappe charts simply from the module's own dir does not work (despite `module` being listed under `package.json`).

Since some issues have come up regarding this, I updated the docs to also mention the direct file import from the `dist/` folder.
Should the example point to the minified file path?