### PR TITLE
Remove minimum height for zero-values in bar chart

### DIFF
--- a/src/js/utils/constants.js
+++ b/src/js/utils/constants.js
@@ -68,7 +68,7 @@ export const AXIS_DATASET_CHART_TYPES = ['line', 'bar'];
 export const AXIS_LEGEND_BAR_SIZE = 100;
 
 export const BAR_CHART_SPACE_RATIO = 0.5;
-export const MIN_BAR_PERCENT_HEIGHT = 0.01;
+export const MIN_BAR_PERCENT_HEIGHT = 0.00;
 
 export const LINE_CHART_DOT_SIZE = 4;
 export const DOT_OVERLAY_SIZE_INCR = 4;


### PR DESCRIPTION
##### Explanation About What Code Achieves:
Fixes #201.

This is really a UX issue.

Previously, if any datapoint was a zero-value, it would still be visible on the chart, making it seem it has non-zero data.

##### Screenshots/GIFs:

Please pardon the insane precision on the values :smile: 

**Before:**

![image](https://user-images.githubusercontent.com/13396535/50213838-beac6600-03a4-11e9-87c3-498a5617430b.png)

**After:**

![image](https://user-images.githubusercontent.com/13396535/50213888-e7ccf680-03a4-11e9-9bfe-b2abc81e3755.png)

##### Steps To Test:
- Refer to a bar or stacked bar chart with zero values - they shouldn't appear on the chart.

##### TODOs:
  - I wasn't able to run the contribution steps locally, and I got the following error on `npm run dev`:

![image](https://user-images.githubusercontent.com/13396535/50214468-58c0de00-03a6-11e9-8bfe-ce1550e0ea5d.png)

So I have no idea how to rebuild the distribution(s). That might need a separate commit/PR.