### PR TITLE
feat: added truncateLegends options

### DIFF
--- a/src/js/charts/AxisChart.js
+++ b/src/js/charts/AxisChart.js
@@ -429,7 +429,8 @@ export default class AxisChart extends BaseChart {
 					'0',
 					barWidth,
 					this.colors[i],
-					d.name);
+					d.name,
+					this.config.truncateLegends);
 				this.legendArea.appendChild(rect);
 			});
 		}

--- a/src/js/charts/BaseChart.js
+++ b/src/js/charts/BaseChart.js
@@ -34,7 +34,8 @@ export default class BaseChart {
 			showTooltip: 1, // calculate
 			showLegend: 1, // calculate
 			isNavigable: options.isNavigable || 0,
-			animate: 1
+			animate: 1,
+			truncateLegends: options.truncateLegends || 0
 		};
 
 		this.measures = JSON.parse(JSON.stringify(BASE_MEASURES));

--- a/src/js/utils/draw-utils.js
+++ b/src/js/utils/draw-utils.js
@@ -24,3 +24,14 @@ export function equilizeNoOfElements(array1, array2,
 	}
 	return [array1, array2];
 }
+
+export function truncateString(txt, len) {
+	if (!txt) {
+		return;
+	}
+	if (txt.length > len) {
+		return txt.slice(0, len-3) + '...';
+	} else {
+		return txt;
+	}
+}

--- a/src/js/utils/draw.js
+++ b/src/js/utils/draw.js
@@ -1,10 +1,11 @@
-import { getBarHeightAndYAttr } from './draw-utils';
+import { getBarHeightAndYAttr, truncateString } from './draw-utils';
 import { getStringWidth } from './helpers';
 import { DOT_OVERLAY_SIZE_INCR, PERCENTAGE_BAR_DEFAULT_DEPTH } from './constants';
 import { lightenDarkenColor } from './colors';
 
 export const AXIS_TICK_LENGTH = 6;
 const LABEL_MARGIN = 4;
+const LABEL_MAX_CHARS = 15;
 export const FONT_SIZE = 10;
 const BASE_LINE_COLOR = '#dadada';
 const FONT_FILL = '#555b51';
@@ -182,7 +183,9 @@ export function heatSquare(className, x, y, size, fill='none', data={}) {
 	return createSVG("rect", args);
 }
 
-export function legendBar(x, y, size, fill='none', label) {
+export function legendBar(x, y, size, fill='none', label, truncate=false) {
+	label = truncate ? truncateString(label, LABEL_MAX_CHARS) : label;
+
 	let args = {
 		className: 'legend-bar',
 		x: 0,


### PR DESCRIPTION
<!-- Thank you so much for contributing! We're glad to have you onboard :) -->
<!-- Please help us understand you contribution better with these details -->

###### Explanation About What Code Achieves:
<!-- Please explain why this code is necessary / what it does -->
  - Long legends would overlap with neighboring legends as shown in the screenshot below, added an option which when enabled, would truncate the legends.

###### Changes in the PR.
1. Added `truncateString` in `draw-utils.js`
1. Added `truncateLegends` options to `config` object and passed it along to `legendBar` in `AxisChart.js`
1. Added a default value for max number of characters `LABEL_MAX_CHARS` in `draw.js`

> NOTE: The default value for `truncateLegends` is `0` (i.e. false)

###### Screenshots/GIFs:
<!-- As this is mainly a visual lib, please include a screenshot/gif if your contribution modifies on-screen components -->
`truncateLegends` not set (or set to false)
<img width="737" alt="Screenshot 2019-07-20 at 10 08 21 PM" src="https://user-images.githubusercontent.com/18097732/61581361-17aacb00-ab3b-11e9-812b-a7767f24cbba.png">

`truncateLegends` set as true
<img width="734" alt="Screenshot 2019-07-20 at 10 08 54 PM" src="https://user-images.githubusercontent.com/18097732/61581367-272a1400-ab3b-11e9-9bf2-a53566cea9b0.png">
