### PR TITLE
feat: allow full circle in piechart

### DIFF
--- a/src/js/charts/DonutChart.js
+++ b/src/js/charts/DonutChart.js
@@ -2,7 +2,7 @@ import AggregationChart from './AggregationChart';
 import { getComponent } from '../objects/ChartComponents';
 import { getOffset } from '../utils/dom';
 import { getPositionByAngle } from '../utils/helpers';
-import { makeArcStrokePathStr } from '../utils/draw';
+import { makeArcStrokePathStr, makeStrokeCircleStr } from '../utils/draw';
 import { lightenDarkenColor } from '../utils/colors';
 import { transform } from '../utils/animation';
 import { FULL_ANGLE } from '../utils/constants';
@@ -63,7 +63,10 @@ export default class DonutChart extends AggregationChart {
 				curStart = startPosition;
 				curEnd = endPosition;
 			}
-			const curPath = makeArcStrokePathStr(curStart, curEnd, this.center, this.radius, this.clockWise, largeArc);
+			const curPath =
+				originDiffAngle === 360
+					? makeStrokeCircleStr(curStart, curEnd, this.center, this.radius, this.clockWise, largeArc)
+					: makeArcStrokePathStr(curStart, curEnd, this.center, this.radius, this.clockWise, largeArc);
 
 			s.sliceStrings.push(curPath);
 			s.slicesProperties.push({

--- a/src/js/charts/PieChart.js
+++ b/src/js/charts/PieChart.js
@@ -2,7 +2,7 @@ import AggregationChart from './AggregationChart';
 import { getComponent } from '../objects/ChartComponents';
 import { getOffset } from '../utils/dom';
 import { getPositionByAngle } from '../utils/helpers';
-import { makeArcPathStr } from '../utils/draw';
+import { makeArcPathStr, makeCircleStr } from '../utils/draw';
 import { lightenDarkenColor } from '../utils/colors';
 import { transform } from '../utils/animation';
 import { FULL_ANGLE } from '../utils/constants';
@@ -58,7 +58,11 @@ export default class PieChart extends AggregationChart {
 				curStart = startPosition;
 				curEnd = endPosition;
 			}
-			const curPath = makeArcPathStr(curStart, curEnd, this.center, this.radius, clockWise, largeArc);
+			const curPath =
+				originDiffAngle === 360
+					? makeCircleStr(curStart, curEnd, this.center, this.radius, clockWise, largeArc)
+					: makeArcPathStr(curStart, curEnd, this.center, this.radius, clockWise, largeArc)
+
 			s.sliceStrings.push(curPath);
 			s.slicesProperties.push({
 				startPosition,

--- a/src/js/charts/PieChart.js
+++ b/src/js/charts/PieChart.js
@@ -61,7 +61,7 @@ export default class PieChart extends AggregationChart {
 			const curPath =
 				originDiffAngle === 360
 					? makeCircleStr(curStart, curEnd, this.center, this.radius, clockWise, largeArc)
-					: makeArcPathStr(curStart, curEnd, this.center, this.radius, clockWise, largeArc)
+					: makeArcPathStr(curStart, curEnd, this.center, this.radius, clockWise, largeArc);
 
 			s.sliceStrings.push(curPath);
 			s.slicesProperties.push({

--- a/src/js/utils/draw.js
+++ b/src/js/utils/draw.js
@@ -141,6 +141,18 @@ export function makeArcStrokePathStr(startPosition, endPosition, center, radius,
 		${arcEndX} ${arcEndY}`;
 }
 
+export function makeStrokeCircleStr(startPosition, endPosition, center, radius, clockWise=1, largeArc=0){
+	let [arcStartX, arcStartY] = [center.x + startPosition.x, center.y + startPosition.y];
+	let [arcEndX, midArc, arcEndY] = [center.x + endPosition.x, radius * 2 + arcStartY, center.y + startPosition.y];
+
+	return `M${arcStartX} ${arcStartY}
+		A ${radius} ${radius} 0 ${largeArc} ${clockWise ? 1 : 0}
+		${arcEndX} ${midArc}
+		M${arcStartX} ${midArc}
+		A ${radius} ${radius} 0 ${largeArc} ${clockWise ? 1 : 0}
+		${arcEndX} ${arcEndY}`;
+}
+
 export function makeGradient(svgDefElem, color, lighter = false) {
 	let gradientId ='path-fill-gradient' + '-' + color + '-' +(lighter ? 'lighter' : 'default');
 	let gradientDef = renderVerticalGradient(svgDefElem, gradientId);

--- a/src/js/utils/draw.js
+++ b/src/js/utils/draw.js
@@ -120,6 +120,18 @@ export function makeArcPathStr(startPosition, endPosition, center, radius, clock
 		${arcEndX} ${arcEndY} z`;
 }
 
+export function makeCircleStr(startPosition, endPosition, center, radius, clockWise=1, largeArc=0){
+	let [arcStartX, arcStartY] = [center.x + startPosition.x, center.y + startPosition.y];
+	let [arcEndX, midArc, arcEndY] = [center.x + endPosition.x, center.y * 2, center.y + endPosition.y];
+	return `M${center.x} ${center.y}
+		L${arcStartX} ${arcStartY}
+		A ${radius} ${radius} 0 ${largeArc} ${clockWise ? 1 : 0}
+		${arcEndX} ${midArc} z
+		L${arcStartX} ${midArc}
+		A ${radius} ${radius} 0 ${largeArc} ${clockWise ? 1 : 0}
+		${arcEndX} ${arcEndY} z`;
+}
+
 export function makeArcStrokePathStr(startPosition, endPosition, center, radius, clockWise=1, largeArc=0){
 	let [arcStartX, arcStartY] = [center.x + startPosition.x, center.y + startPosition.y];
 	let [arcEndX, arcEndY] = [center.x + endPosition.x, center.y + endPosition.y];


### PR DESCRIPTION
Solves https://github.com/frappe/charts/issues/186
<!-- Thank you so much for contributing! We're glad to have you onboard :) -->
<!-- Please help us understand you contribution better with these details -->

###### Explanation About What Code Achieves:
<!-- Please explain why this code is necessary / what it does -->
The PR adds a full circle check to pie chart and donut chart, this is required when a single data point is given to these charts, or when all but one data points have the value zero. 

Using the SVGs arc path, one can draw 99.999% of the circle but not a complete circle, this doesn't work because the starting point and ending point of the arc is the same for a circle, so I guess the browser does not bother to draw the SVG, it's similar to drawing a line from (10, 10) to (10, 10) you get no line. Normally it would be wise to use the `<circle>` tag, but that may require bigger changes and can be a part of a different release, so right now we use a clever hack to solve this problem. 

The `d` attribute will accept and draw all valid [`path command`](https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/d#Path_commands) strings, The trick is to have two arcs, the second one picking up where the first left off and get back to the original arc start point. [[ref](https://stackoverflow.com/a/10477334)]

###### Screenshots/GIFs:
<!-- As this is mainly a visual lib, please include a screenshot/gif if your contribution modifies on-screen components -->
Previously as mentioned here https://github.com/frappe/charts/issues/186 the chart would not render at all. After the fix, the rendering in either cases works fine:

|  | Pie Chart  | Donut Chart          |
|----------|---|-------------------|
| With Single Data  | <img width="729" alt="Screenshot 2019-07-30 at 9 56 07 AM" src="https://user-images.githubusercontent.com/18097732/62101070-bb217b80-b2b1-11e9-9052-5e62a4f4e9d9.png"> | <img width="731" alt="Screenshot 2019-07-30 at 9 55 52 AM" src="https://user-images.githubusercontent.com/18097732/62101101-dee4c180-b2b1-11e9-83e5-88180cd55a56.png"> |
| With Multiple Data  | <img width="729" alt="Screenshot 2019-07-30 at 9 56 42 AM" src="https://user-images.githubusercontent.com/18097732/62101111-ea37ed00-b2b1-11e9-8fd6-787cbb90a281.png"> | <img width="731" alt="Screenshot 2019-07-30 at 9 56 59 AM" src="https://user-images.githubusercontent.com/18097732/62101128-f6bc4580-b2b1-11e9-8b1c-548cb1813191.png"> |
