### PR TITLE
fix: destroying event listener on window

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -261,7 +261,7 @@ redirect_to: "https://frappe.io/charts"
   chart.export();
 
   // Unbind window-resize events
-  chart.unbindWindowEvents();
+  chart.destroy();
 
 </code></pre>
     </section>

--- a/src/js/charts/BaseChart.js
+++ b/src/js/charts/BaseChart.js
@@ -7,8 +7,6 @@ import { getColor, isValidColor } from '../utils/colors';
 import { runSMILAnimation } from '../utils/animation';
 import { downloadFile, prepareForExport } from '../utils/export';
 
-let BOUND_DRAW_FN;
-
 export default class BaseChart {
 	constructor(parent, options) {
 
@@ -90,18 +88,14 @@ export default class BaseChart {
 		this.height = height - getExtraHeight(this.measures);
 
 		// Bind window events
-		BOUND_DRAW_FN = this.boundDrawFn.bind(this);
-		window.addEventListener('resize', BOUND_DRAW_FN);
-		window.addEventListener('orientationchange', this.boundDrawFn.bind(this));
+		this.boundDrawFn = () => this.draw(true);
+		window.addEventListener('resize', this.boundDrawFn);
+		window.addEventListener('orientationchange', this.boundDrawFn);
 	}
 
-	boundDrawFn() {
-		this.draw(true);
-	}
-
-	unbindWindowEvents() {
-		window.removeEventListener('resize', BOUND_DRAW_FN);
-		window.removeEventListener('orientationchange', this.boundDrawFn.bind(this));
+	destroy() {
+		window.removeEventListener('resize', this.boundDrawFn);
+		window.removeEventListener('orientationchange', this.boundDrawFn);
 	}
 
 	// Has to be called manually


### PR DESCRIPTION
Solving the following issues: https://github.com/frappe/charts/issues/168, https://github.com/frappe/charts/issues/210, https://github.com/frappe/charts/issues/200, https://github.com/frappe/charts/issues/168

- All these issues report that event listeners would not be removed properly causing issues in resizing, or when switching to a different view in SPAs
- The `boundDrawFn` was necessarily complicated, we need not attach it to a 'global' variable `BOUND_DRAW_FN`, it can be made available to `this`
- the `unbindWindowEvents` function (which unbinds all `window` events) is not a good naming choice for an API (It is renamed to `destroy`)

This PR fixes all of that.