### PR TITLE
Feature/truncate legend dot labels

### DIFF
--- a/src/js/charts/AggregationChart.js
+++ b/src/js/charts/AggregationChart.js
@@ -80,7 +80,8 @@ export default class AggregationChart extends BaseChart {
 				y,
 				5,
 				this.colors[i],
-				`${s.labels[i]}: ${d}`
+				`${s.labels[i]}: ${d}`,
+				this.config.truncateLegends
 			);
 			this.legendArea.appendChild(dot);
 			count++;

--- a/src/js/utils/draw.js
+++ b/src/js/utils/draw.js
@@ -238,7 +238,9 @@ export function legendBar(x, y, size, fill='none', label, truncate=false) {
 	return group;
 }
 
-export function legendDot(x, y, size, fill='none', label) {
+export function legendDot(x, y, size, fill='none', label, truncate=false) {
+	label = truncate ? truncateString(label, LABEL_MAX_CHARS) : label;
+
 	let args = {
 		className: 'legend-dot',
 		cx: 0,


### PR DESCRIPTION
###### Explanation About What Code Achieves:
  - When using pie charts legends with large numbers will overlap making the legend unreadable.
  - Changed _renderLegend_ in _AggregationChart_ to pass _truncateLegends_ option.
  - Changed _legendDot_ signature and logic to truncate the legend.

###### Screenshots/GIFs:
* Before:
![image](https://user-images.githubusercontent.com/14946058/64696311-62dbbd00-d49e-11e9-994f-139a5a5fbc4a.png)

* After:
![image](https://user-images.githubusercontent.com/14946058/64696558-f614f280-d49e-11e9-940c-c20be649e6d6.png)



