### PR TITLE
Fix: Sometimes index === -1

### DIFF
--- a/src/js/charts/AxisChart.js
+++ b/src/js/charts/AxisChart.js
@@ -405,17 +405,19 @@ export default class AxisChart extends BaseChart {
 		if(!s.yExtremes) return;
 
 		let index = getClosestInArray(relX, s.xAxis.positions, true);
-		let dbi = this.dataByIndex[index];
+		if (index >= 0) {
+			let dbi = this.dataByIndex[index];
 
-		this.tip.setValues(
-			dbi.xPos + this.tip.offset.x,
-			dbi.yExtreme + this.tip.offset.y,
-			{name: dbi.formattedLabel, value: ''},
-			dbi.values,
-			index
-		);
+			this.tip.setValues(
+				dbi.xPos + this.tip.offset.x,
+				dbi.yExtreme + this.tip.offset.y,
+				{name: dbi.formattedLabel, value: ''},
+				dbi.values,
+				index
+			);
 
-		this.tip.showTip();
+			this.tip.showTip();
+		}
 	}
 
 	renderLegend() {


### PR DESCRIPTION
Sometimes when mouse-overing container, i got `vendors.app.js:8427 Uncaught TypeError: Cannot read property 'xPos' of undefined` that is caused by `-1` index

<!-- Thank you so much for contributing! We're glad to have you onboard :) -->
<!-- Please help us understand you contribution better with these details -->

###### Explanation About What Code Achieves:
<!-- Please explain why this code is necessary / what it does -->
  - To disable `-1` index tooltip when hovering container

###### Screenshots/GIFs:
<!-- As this is mainly a visual lib, please include a screenshot/gif if your contribution modifies on-screen components -->
<img width="515" alt="Screenshot 2019-10-07 at 14 39 07" src="https://user-images.githubusercontent.com/3534160/66308991-1eaed180-e911-11e9-960c-0605b9dd7d1d.png">