### PR TITLE
Allow withMinimum behavior of calcYAxisParameters() to be set as opt…

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -205,6 +205,7 @@ redirect_to: "https://frappe.io/charts"
       title: '',
       colors: [],
       height: 200,
+      withMinimum: false,    // set to false to have the Y axis start from 0, default: true for line charts
 
       tooltipOptions: {
         formatTooltipX: d => (d + '').toUpperCase(),

--- a/src/js/charts/AxisChart.js
+++ b/src/js/charts/AxisChart.js
@@ -17,6 +17,7 @@ export default class AxisChart extends BaseChart {
 		this.lineOptions = args.lineOptions || {};
 
 		this.type = args.type || 'line';
+		this.withMinimum = args.withMinimum !== undefined ? args.withMinimum : args.type || 'line';
 		this.init = 1;
 
 		this.setup();
@@ -57,7 +58,7 @@ export default class AxisChart extends BaseChart {
 	calc(onlyWidthChange = false) {
 		this.calcXPositions();
 		if(!onlyWidthChange) {
-			this.calcYAxisParameters(this.getAllYValues(), this.type === 'line');
+			this.calcYAxisParameters(this.getAllYValues(), this.withMinimum);
 		}
 		this.makeDataByIndex();
 	}


### PR DESCRIPTION
Allow withMinimum behavior of `calcYAxisParameters() `to be set as option for the chart.

<!-- Thank you so much for contributing! We're glad to have you onboard :) -->
<!-- Please help us understand you contribution better with these details -->

###### Explanation About What Code Achieves:
<!-- Please explain why this code is necessary / what it does -->
  - I have a line chart displayed, that has the values in the range ~200k-300k. The Y axis range is 100k-300k. I would like to force the Y axis to show the range 0-300k. I identified in code the method that calculates the range, `calcYAxisParameters()`, and saw that it has a parameter `withMinimum`, but it is set automatically to true if the chart is of type 'line'. My change allows this to be set as a parameter for the chart. If it's not set, it will maintain the current behavior, so there are no breaking changes. 

###### Screenshots/GIFs:
<!-- As this is mainly a visual lib, please include a screenshot/gif if your contribution modifies on-screen components -->
Before:
<img width="1320" alt="before" src="https://user-images.githubusercontent.com/4013741/71079400-e2f77a00-2193-11ea-96bf-f75c359172bb.png">
After:
<img width="1315" alt="after" src="https://user-images.githubusercontent.com/4013741/71079406-e7239780-2193-11ea-99f1-4cc0c18a6042.png">



###### Steps To Test:
<!-- What would someone do to be able to see the effects of your code? -->
  - Create a line chart with values in the range ~200k-300k
  - See that the chart lines go below the baseline of the chart, and the Y axis range is 100k-300k
  - Add to the options object the option: `withMinimum: false`
  - See that the chart lines go only to the baseline of the chart, and the Y axis range is 0-300k


###### TODOs:
<!-- Is there any tests or logic that isn't in the pr that you want the reviewer to know about? -->
  - None
