### PR TITLE
Update axis-chart-utils.js

### DIFF
--- a/src/js/utils/axis-chart-utils.js
+++ b/src/js/utils/axis-chart-utils.js
@@ -101,6 +101,13 @@ export function getShortenedLabels(chartWidth, labels=[], isSeries=true) {
 	if(allowedSpace <= 0) allowedSpace = 1;
 	let allowedLetters = allowedSpace / DEFAULT_CHAR_WIDTH;
 
+	let seriesMultiple;
+	if(isSeries) {
+		// Find the maximum label length for spacing calculations
+		let maxLabelLength = Math.max(...labels.map(label => label.length));
+		seriesMultiple = Math.ceil(maxLabelLength/allowedLetters);
+	}
+
 	let calcLabels = labels.map((label, i) => {
 		label += "";
 		if(label.length > allowedLetters) {
@@ -112,8 +119,7 @@ export function getShortenedLabels(chartWidth, labels=[], isSeries=true) {
 					label = label.slice(0, allowedLetters) + '..';
 				}
 			} else {
-				let multiple = Math.ceil(label.length/allowedLetters);
-				if(i % multiple !== 0) {
+				if(i % seriesMultiple !== 0) {
 					label = "";
 				}
 			}


### PR DESCRIPTION
Fix issue with overlapping labels on series charts. 

###### Explanation About What Code Achieves:

Fixes the series chart overlapping label issue here:

https://github.com/frappe/charts/issues/158

The issue was caused by the label overlapping logic only showing every Nth label. However N could change for each unique label length resulting in strange overlaps when the label length would change.

We now just choose one label length (the longest label) and use that throughout for spacing.

###### Screenshots/GIFs:

See here for a screenshot of the issue:

https://github.com/frappe/charts/issues/158

###### Steps To Test:

Create a series chart with labels that have a different number of characters. View before and after this change

###### TODOs:

  - None
