### PR TITLE
Add whiteLabels configuration option

### DIFF
--- a/src/js/charts/AxisChart.js
+++ b/src/js/charts/AxisChart.js
@@ -44,6 +44,7 @@ export default class AxisChart extends BaseChart {
 		this.config.formatTooltipY = options.tooltipOptions.formatTooltipY;
 
 		this.config.valuesOverPoints = options.valuesOverPoints;
+		this.config.whiteLabels = options.whiteLabels || 0;
 	}
 
 	prepareData(data=this.data) {
@@ -193,7 +194,8 @@ export default class AxisChart extends BaseChart {
 				{
 					mode: this.config.yAxisMode,
 					width: this.width,
-					shortenNumbers: this.config.shortenYAxisNumbers
+					shortenNumbers: this.config.shortenYAxisNumbers,
+					whiteLabels: this.config.whiteLabels,
 					// pos: 'right'
 				},
 				function() {
@@ -206,6 +208,7 @@ export default class AxisChart extends BaseChart {
 				{
 					mode: this.config.xAxisMode,
 					height: this.height,
+					whiteLabels: this.config.whiteLabels,
 					// pos: 'right'
 				},
 				function() {
@@ -243,6 +246,7 @@ export default class AxisChart extends BaseChart {
 
 					// same for all datasets
 					valuesOverPoints: this.config.valuesOverPoints,
+					whiteLabels: this.config.whiteLabels,
 					minHeight: this.height * MIN_BAR_PERCENT_HEIGHT,
 				},
 				function() {
@@ -304,6 +308,7 @@ export default class AxisChart extends BaseChart {
 
 					// same for all datasets
 					valuesOverPoints: this.config.valuesOverPoints,
+					whiteLabels: this.config.whiteLabels,
 				},
 				function() {
 					let s = this.state;

--- a/src/js/objects/ChartComponents.js
+++ b/src/js/objects/ChartComponents.js
@@ -119,7 +119,13 @@ let componentConfigs = {
 		makeElements(data) {
 			return data.positions.map((position, i) =>
 				yLine(position, data.labels[i], this.constants.width,
-					{mode: this.constants.mode, pos: this.constants.pos, shortenNumbers: this.constants.shortenNumbers})
+					{
+						mode: this.constants.mode, 
+						pos: this.constants.pos, 
+						shortenNumbers: this.constants.shortenNumbers,
+						whiteLabels: this.constants.whiteLabels
+					}
+				)
 			);
 		},
 
@@ -150,7 +156,12 @@ let componentConfigs = {
 		makeElements(data) {
 			return data.positions.map((position, i) =>
 				xLine(position, data.calcLabels[i], this.constants.height,
-					{mode: this.constants.mode, pos: this.constants.pos})
+					{
+						mode: this.constants.mode, 
+						pos: this.constants.pos, 
+						whiteLabels: this.constants.whiteLabels
+					}
+				)
 			);
 		},
 
@@ -304,6 +315,7 @@ let componentConfigs = {
 					data.barWidth,
 					c.color,
 					data.labels[j],
+					c.whiteLabels,
 					j,
 					data.offsets[j],
 					{
@@ -387,6 +399,7 @@ let componentConfigs = {
 						data.radius,
 						c.color,
 						(c.valuesOverPoints ? data.values[j] : ''),
+						c.whiteLabels,
 						j
 					);
 				});

--- a/src/js/utils/draw.js
+++ b/src/js/utils/draw.js
@@ -9,6 +9,7 @@ const LABEL_MAX_CHARS = 15;
 export const FONT_SIZE = 10;
 const BASE_LINE_COLOR = '#dadada';
 const FONT_FILL = '#555b51';
+const LIGHTER_FONT_FILL = '#888c85';
 
 function $(expr, con) {
 	return typeof expr === "string"? (con || document).querySelector(expr) : expr || null;
@@ -306,7 +307,8 @@ function makeVertLine(x, label, y1, y2, options={}) {
 		dy: FONT_SIZE + 'px',
 		'font-size': FONT_SIZE + 'px',
 		'text-anchor': 'middle',
-		innerHTML: label + ""
+		innerHTML: label + "",
+		style: `fill: ${options.whiteLabels ? LIGHTER_FONT_FILL : FONT_FILL}`
 	});
 
 	let line = createSVG('g', {
@@ -344,7 +346,8 @@ function makeHoriLine(y, label, x1, x2, options={}) {
 		dy: (FONT_SIZE / 2 - 2) + 'px',
 		'font-size': FONT_SIZE + 'px',
 		'text-anchor': x1 < x2 ? 'end' : 'start',
-		innerHTML: label+""
+		innerHTML: label+"",
+		style: `fill: ${options.whiteLabels ? LIGHTER_FONT_FILL : FONT_FILL}`
 	});
 
 	let line = createSVG('g', {
@@ -388,6 +391,7 @@ export function yLine(y, label, width, options={}) {
 		stroke: options.stroke,
 		className: options.className,
 		lineType: options.lineType,
+		whiteLabels: options.whiteLabels,
 		shortenNumbers: options.shortenNumbers
 	});
 }
@@ -424,7 +428,8 @@ export function xLine(x, label, height, options={}) {
 	return makeVertLine(x, label, y1, y2, {
 		stroke: options.stroke,
 		className: options.className,
-		lineType: options.lineType
+		lineType: options.lineType,
+		whiteLabels: options.whiteLabels
 	});
 }
 
@@ -496,7 +501,7 @@ export function yRegion(y1, y2, width, label, options={}) {
 	return region;
 }
 
-export function datasetBar(x, yTop, width, color, label='', index=0, offset=0, meta={}) {
+export function datasetBar(x, yTop, width, color, label='', whiteLabels=false, index=0, offset=0, meta={}) {
 	let [height, y] = getBarHeightAndYAttr(yTop, meta.zeroLine);
 	y -= offset;
 
@@ -535,7 +540,8 @@ export function datasetBar(x, yTop, width, color, label='', index=0, offset=0, m
 			dy: (FONT_SIZE / 2 * -1) + 'px',
 			'font-size': FONT_SIZE + 'px',
 			'text-anchor': 'middle',
-			innerHTML: label
+			innerHTML: label,
+			style: `fill: ${whiteLabels ? 'white' : 'black'}`
 		});
 
 		let group = createSVG('g', {
@@ -549,7 +555,7 @@ export function datasetBar(x, yTop, width, color, label='', index=0, offset=0, m
 	}
 }
 
-export function datasetDot(x, y, radius, color, label='', index=0) {
+export function datasetDot(x, y, radius, color, label='', whiteLabels=false, index=0) {
 	let dot = createSVG('circle', {
 		style: `fill: ${color}`,
 		'data-point-index': index,
@@ -573,7 +579,8 @@ export function datasetDot(x, y, radius, color, label='', index=0) {
 			dy: (FONT_SIZE / 2 * -1 - radius) + 'px',
 			'font-size': FONT_SIZE + 'px',
 			'text-anchor': 'middle',
-			innerHTML: label
+			innerHTML: label,
+			style: `fill: ${whiteLabels ? 'white' : 'black'}`
 		});
 
 		let group = createSVG('g', {


### PR DESCRIPTION
<!-- Thank you so much for contributing! We're glad to have you onboard :) -->
<!-- Please help us understand you contribution better with these details -->

###### Explanation About What Code Achieves:
<!-- Please explain why this code is necessary / what it does -->
Some labels become hard to read on dark backgrounds, so I added a configuration option to change their color and make them more visible, this applies to axis charts. 

###### Screenshots/GIFs:
<!-- As this is mainly a visual lib, please include a screenshot/gif if your contribution modifies on-screen components -->
Before / After
![frappe-chart](https://user-images.githubusercontent.com/35016005/88072225-674f1880-cb3a-11ea-8c10-4dd212a54367.png)


###### Steps To Test:
<!-- What would someone do to be able to see the effects of your code? -->
  Set `whiteLabels: true`
