### PR TITLE
feat: use UMD instead of IIFE for browser target

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@
     <a href="https://travis-ci.org/frappe/charts">
         <img src="https://img.shields.io/travis/frappe/charts.svg?style=flat-square">
     </a>
-    <a href="http://github.com/frappe/charts/tree/master/dist/js/frappe-charts.min.iife.js">
-        <img src="http://img.badgesize.io/frappe/charts/master/dist/frappe-charts.min.iife.js.svg?compression=gzip">
+    <a href="http://github.com/frappe/charts/tree/master/dist/js/frappe-charts.min.umd.js">
+        <img src="http://img.badgesize.io/frappe/charts/master/dist/frappe-charts.min.umd.js.svg?compression=gzip">
     </a>
 </p>
 
@@ -58,9 +58,9 @@
 * ...or include within your HTML
 
   ```html
-    <script src="https://cdn.jsdelivr.net/npm/frappe-charts@1.1.0/dist/frappe-charts.min.iife.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/frappe-charts@1.1.0/dist/frappe-charts.min.umd.js"></script>
     <!-- or -->
-    <script src="https://unpkg.com/frappe-charts@1.1.0/dist/frappe-charts.min.iife.js"></script>
+    <script src="https://unpkg.com/frappe-charts@1.1.0/dist/frappe-charts.min.umd.js"></script>
   ```
 
 #### Usage
@@ -152,4 +152,3 @@ This repository has been released under the [MIT License](LICENSE)
 ------------------
 Project maintained by [Frappe](https://frappe.io).
 Used in [ERPNext](https://erpnext.com). Read the [blog post](https://medium.com/@pratu16x7/so-we-decided-to-create-our-own-charts-a95cb5032c97).
-

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "dist/frappe-charts.min.cjs.js",
   "module": "dist/frappe-charts.min.esm.js",
   "src": "dist/frappe-charts.esm.js",
-  "browser": "dist/frappe-charts.min.iife.js",
+  "browser": "dist/frappe-charts.min.umd.js",
   "directories": {
     "doc": "docs"
   },

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -48,7 +48,7 @@ export default [
 			},
 			{
 				file: pkg.browser,
-				format: 'iife',
+				format: 'umd',
 			}
 		],
 		name: 'frappe',


### PR DESCRIPTION
###### Explanation About What Code Achieves:

This is an attempt to fix https://github.com/frappe/charts/issues/199 (as well as [downstream issues](https://github.com/himynameisdave/svelte-frappe-charts/issues/32) in my `svelte-frappe-charts` wrapper library).

I tried to explain why this is happening [here](https://github.com/frappe/charts/issues/199#issuecomment-809623242). Allow me to summarize:

- Users who install this dependency and consume it the "modern way", via installing and importing it (as described in the README):
    ```typescript
    import { Chart } from 'frappe-charts';
    ```
- By importing from `frappe-charts` (not a specific file like `.esm.js`), we are allowing our bundler to resolve what `frappe-charts` means.
- Generally bundlers mostly align with Node's [module resolution algorithm](https://nodejs.org/api/modules.html#modules_all_together). Some have more options. [Here's webpack's](https://webpack.js.org/concepts/module-resolution/).
- This means that Node will reach into `frappe-charts`, inspect its `package.json` and hopefully resolve to _some_ entry file specified there. Luckily [`frappe-charts` specifies this](https://github.com/frappe/charts/blob/master/package.json#L5-L8).
- The error happens because some users, who are bundling JS for the browser, correctly set `browser` as the target in their bundler. This resolves to the `.iife.js` file currently.
- _**IIFE files do not export anything / cannot be consumed in those environments. This is why we are seeing this error.**_

Users _can_ probably get around this issue in their bundler with some Regex gymastics / explicitly telling `frappe-charts` to resolve to _not_ the `browser` version. Or they can do what the README says and manually specify the path to the `.esm.js`.

**The user shouldn't have to do either of these.** Also, how are libraries which consume `frappe-charts` meant to import it? (we believe they should [be agnostic and let the bundler decide](https://github.com/himynameisdave/svelte-frappe-charts/pull/31#issue-597365897)).

This PR tells Rollup to produce a UMD-style bundle, and sets that as the `browser` entry point.

📄 You can read more about [IIFE vs UMD here](https://www.syntaxsuccess.com/viewarticle/iife-vs-umd).


###### Screenshots/GIFs:
- N/A

###### Steps To Test:
- One good test would be to run `npm run build`, grab the `.umd.` output file, stick it in an HTML file and open in a browser and ensure that `window.frappe.Chart` is still available and works as expected.
- I will put together a repo where we can test both import setups and ensure this is fixed.

###### TODOs:
- We may want to update our build dependencies, especially `rollup` and associated plugins. They have made massive improvements since the version we are using now.
- I didn't upload any of the built `dist` files, since I assumed that they get built before release. They are in git though, so let me know if you want me to push them.
