### PR TITLE
Option to format values over points on bar chart and/or line chart

### DIFF
--- a/src/js/charts/AxisChart.js
+++ b/src/js/charts/AxisChart.js
@@ -8,6 +8,7 @@ import { floatTwo } from '../utils/helpers';
 import { makeOverlay, updateOverlay, legendBar } from '../utils/draw';
 import { getTopOffset, getLeftOffset, MIN_BAR_PERCENT_HEIGHT, BAR_CHART_SPACE_RATIO,
 	LINE_CHART_DOT_SIZE } from '../utils/constants';
+import { shortenLargeNumber } from '../utils/draw-utils';
 
 export default class AxisChart extends BaseChart {
 	constructor(parent, args) {
@@ -243,6 +244,7 @@ export default class AxisChart extends BaseChart {
 
 					// same for all datasets
 					valuesOverPoints: this.config.valuesOverPoints,
+					formatValuesOverPoints: this.barOptions.formatValuesOverPoints || 0,
 					minHeight: this.height * MIN_BAR_PERCENT_HEIGHT,
 				},
 				function() {
@@ -265,6 +267,10 @@ export default class AxisChart extends BaseChart {
 							labels = d.cumulativeYs;
 						} else {
 							labels = d.values;
+						}
+
+						if(this.barOptions.formatValuesOverPoints) {
+							labels = labels.map((l) => this.shortenLargeNumber(l));
 						}
 					}
 
@@ -304,12 +310,17 @@ export default class AxisChart extends BaseChart {
 
 					// same for all datasets
 					valuesOverPoints: this.config.valuesOverPoints,
+					formatValuesOverPoints: this.lineOptions.formatValuesOverPoints || 0
 				},
 				function() {
 					let s = this.state;
 					let d = s.datasets[index];
 					let minLine = s.yAxis.positions[0] < s.yAxis.zeroLine
 						? s.yAxis.positions[0] : s.yAxis.zeroLine;
+
+					if(this.config.formatValuesOverPoints) {
+						d.values = d.values.map((v) => shortenLargeNumber(v));
+					}
 
 					return {
 						xPositions: s.xAxis.positions,


### PR DESCRIPTION
<!-- Thank you so much for contributing! We're glad to have you onboard :) -->
<!-- Please help us understand you contribution better with these details -->

###### Explanation About What Code Achieves:
<!-- Please explain why this code is necessary / what it does -->
  - When people use this chart to display bigger numbers (eg. > 1000, > 10.000) they would be grateful to have an option to shorten those numbers (eg. 1K, 10K, 100K, 1M), and the graph would be more readable with shortening numbers.

###### Screenshots/GIFs:
<!-- As this is mainly a visual lib, please include a screenshot/gif if your contribution modifies on-screen components -->
<img width="1313" alt="Screenshot 2021-05-09 at 10 25 49" src="https://user-images.githubusercontent.com/26303541/117565347-f53bc600-b0b0-11eb-9173-919bfaa73d92.png">

###### Steps To Test:
<!-- What would someone do to be able to see the effects of your code? -->
  - Add `formatValuesOverPoints: true` in bar or line options object

###### TODOs:
<!-- Is there any tests or logic that isn't in the pr that you want the reviewer to know about? -->
  - Should be added to the documentation
  - Option could be in global config instead of in barOptions and lineOptions
