### PR TITLE
fix: fix rounding error in y-axis when max less than 1

### DIFF
--- a/src/js/utils/intervals.js
+++ b/src/js/utils/intervals.js
@@ -69,7 +69,15 @@ function getChartIntervals(maxValue, minValue=0) {
 	normalMaxValue = normalMaxValue.toFixed(6);
 
 	let intervals = getChartRangeIntervals(normalMaxValue, normalMinValue);
-	intervals = intervals.map(value => value * Math.pow(10, exponent));
+	intervals = intervals.map(value => {
+		// For negative exponents we want to divide by 10^-exponent to avoid
+		// floating point arithmetic bugs. For instance, in javascript
+		// 6 * 10^-1 == 0.6000000000000001, we instead want 6 / 10^1 == 0.6
+		if (exponent < 0) {
+			return value / Math.pow(10, -exponent);
+		}
+		return value * Math.pow(10, exponent);
+	});
 	return intervals;
 }
 


### PR DESCRIPTION
<!-- Thank you so much for contributing! We're glad to have you onboard :) -->
<!-- Please help us understand you contribution better with these details -->

###### Explanation About What Code Achieves:
Fixes this rounding issue:
![image](https://user-images.githubusercontent.com/875591/127074361-31ba17c7-409e-45f2-926b-8cab8903d4d3.png)

So that ticks are calculated without rounding errors.

You can run getChartIntervals(0.8) to replicate this behavior:
```
getChartIntervals(0.8) === [ 0, 0.2, 0.4, 0.6000000000000001, 0.8 ]
```

I'm on version 1.6.1. Couldn't test 1.6.2 because it caused a separate bug for me and also the css file isn't present in dist/:
https://unpkg.com/browse/frappe-charts@1.6.2/dist/

###### Screenshots/GIFs:
See above

###### Steps To Test:
Create a chart where the maximum value is 0.8.

I tried to write some test cases for this but the project doesn't have a `test` command (even thought it has some test files)
