### PR TITLE
Accept CSS Vars as valid colours

### DIFF
--- a/src/js/utils/colors.js
+++ b/src/js/utils/colors.js
@@ -35,11 +35,10 @@ export function lightenDarkenColor(color, amt) {
 	return (usePound?"#":"") + (g | (b << 8) | (r << 16)).toString(16);
 }
 
-export function isValidColor(string) {
-	// https://stackoverflow.com/a/32685393
-	let HEX_RE = /(^\s*)(#)((?:[A-Fa-f0-9]{3}){1,2})$/i;
-	let RGB_RE = /(^\s*)(rgb|hsl)(a?)[(]\s*([\d.]+\s*%?)\s*,\s*([\d.]+\s*%?)\s*,\s*([\d.]+\s*%?)\s*(?:,\s*([\d.]+)\s*)?[)]$/i;
-	return HEX_RE.test(string) || RGB_RE.test(string);
+export const isValidColor = (string) => {
+	const s = new Option().style;
+	s.color = string;
+	return s.color.length > 0;
 }
 
 export const getColor = (color) => {


### PR DESCRIPTION
###### Explanation About What Code Achieves:
  - The CSS colour validator is tweaked to allow CSS Vars 

###### Steps To Test:
  - codepen: https://codepen.io/dgrammatiko/pen/ZEyONqJ

![Screenshot 2021-09-03 at 18 35 58](https://user-images.githubusercontent.com/3889375/132039528-514a6094-22ad-47c2-b398-7e0dfaba1fff.png)


###### TODOs:
  - None


