### PR TITLE
Format tooltip based on dataset index

### DIFF
--- a/docs/assets/js/index.js
+++ b/docs/assets/js/index.js
@@ -39,7 +39,10 @@ let typeChartArgs = {
 
 	tooltipOptions: {
 		formatTooltipX: d => (d + '').toUpperCase(),
-		formatTooltipY: d => d + ' pts',
+		formatTooltipY: (d, i) => {
+			let suffix = (i === 0) ? ' pts' : (i === 1) ? ' $' : ' %';
+			return d + suffix;
+		},
 	}
 };
 

--- a/docs/assets/js/index.js
+++ b/docs/assets/js/index.js
@@ -40,7 +40,7 @@ let typeChartArgs = {
 	tooltipOptions: {
 		formatTooltipX: d => (d + '').toUpperCase(),
 		formatTooltipY: (d, i) => {
-			let suffix = (i === 0) ? ' pts' : (i === 1) ? ' $' : ' %';
+			const suffix = (i === 0) ? ' pts' : (i === 1) ? ' $' : ' %';
 			return d + suffix;
 		},
 	}

--- a/docs/index.html
+++ b/docs/index.html
@@ -71,7 +71,10 @@ redirect_to: "https://frappe.io/charts"
 
     tooltipOptions: {
       formatTooltipX: d => (d + '').toUpperCase(),
-      formatTooltipY: d => d + ' pts',
+      formatTooltipY: (d, i) => {
+        const suffix = (i === 0) ? ' pts' : (i === 1) ? ' $' : ' %';
+        return d + suffix;
+      },
     }
   });
 

--- a/src/js/charts/AxisChart.js
+++ b/src/js/charts/AxisChart.js
@@ -369,7 +369,7 @@ export default class AxisChart extends BaseChart {
 					value: value,
 					yPos: set.yPositions[index],
 					color: this.colors[i],
-					formatted: formatY ? formatY(value) : value,
+					formatted: formatY ? formatY(value, i) : value,
 				};
 			});
 


### PR DESCRIPTION
First of all, thank you for your work; I have not seen a chart looking this good out of the box, which such a small footprint.

###### Explanation About What Code Achieves:
This small change makes it possible to format the value from a dataset. this way I could have to datasets from different types to be displayed in the same chart (Example: Rank (#), Value ($))
```js
let values = this.state.datasets.map((set, i) => {
  let value = set.values[index];
  return {
	title: set.name,
	value: value,
	yPos: set.yPositions[index],
	color: this.colors[i],
	formatted: formatY ? formatY(value, i) : value,  // extending the function with i as `index`
  };
});
```


Passing through the index from the mapping function, we can now format based on the index of the dataset, making it easy to have multiple formatting rules without breaking current implementations.


###### Screenshots/GIFs:
<img width="614" alt="Screenshot 2021-12-17 at 11 07 43" src="https://user-images.githubusercontent.com/26795741/146487444-2f7897f4-1678-4d3a-b3b6-6f4fb1c9480c.png">


###### Steps To Test:
Run `yarn dev` and open the `index.html` in docs.

or use the following `formatTooltipY` example 

```js
tooltipOptions: {
  formatTooltipY: (d, i) => {
    const suffix = (i === 0) ? ' #' :  ' $';
    return d + suffix;
  },
}
```
###### TODOs:
<!-- Is there any tests or logic that isn't in the pr that you want the reviewer to know about? -->
  - None
