### PR TITLE
feat: custom number formatter function

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,14 @@
+# Root editor config file
+root = true
+
+# Common settings
+[*]
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+charset = utf-8
+
+# indentation settings
+[{*.js,*.css,*.html}]
+indent_style = tab
+indent_size = 4

--- a/src/js/charts/AxisChart.js
+++ b/src/js/charts/AxisChart.js
@@ -40,6 +40,8 @@ export default class AxisChart extends BaseChart {
 		this.config.yAxisMode = options.axisOptions.yAxisMode || 'span';
 		this.config.xIsSeries = options.axisOptions.xIsSeries || 0;
 		this.config.shortenYAxisNumbers = options.axisOptions.shortenYAxisNumbers || 0;
+		this.config.numberFormatter = options.axisOptions.numberFormatter;
+
 		this.config.yAxisRange = options.axisOptions.yAxisRange || {},
 
 		this.config.formatTooltipX = options.tooltipOptions.formatTooltipX;
@@ -196,8 +198,8 @@ export default class AxisChart extends BaseChart {
 				{
 					mode: this.config.yAxisMode,
 					width: this.width,
-					shortenNumbers: this.config.shortenYAxisNumbers
-					// pos: 'right'
+					shortenNumbers: this.config.shortenYAxisNumbers,
+					numberFormatter: this.config.numberFormatter,
 				},
 				function () {
 					return this.state.yAxis;

--- a/src/js/objects/ChartComponents.js
+++ b/src/js/objects/ChartComponents.js
@@ -125,7 +125,12 @@ let componentConfigs = {
 		makeElements(data) {
 			return data.positions.map((position, i) =>
 				yLine(position, data.labels[i], this.constants.width,
-					{ mode: this.constants.mode, pos: this.constants.pos, shortenNumbers: this.constants.shortenNumbers })
+					{
+						mode: this.constants.mode,
+						pos: this.constants.pos,
+						shortenNumbers: this.constants.shortenNumbers,
+						numberFormatter: this.constants.numberFormatter
+					})
 			);
 		},
 

--- a/src/js/utils/draw.js
+++ b/src/js/utils/draw.js
@@ -324,7 +324,13 @@ function makeVertLine(x, label, y1, y2, options = {}) {
 
 function makeHoriLine(y, label, x1, x2, options = {}) {
 	if (!options.lineType) options.lineType = '';
-	if (options.shortenNumbers) label = shortenLargeNumber(label);
+	if (options.shortenNumbers) {
+		if (options.numberFormatter) {
+			label = options.numberFormatter(label);
+		} else {
+			label = shortenLargeNumber(label);
+		}
+	}
 
 	let className = 'line-horizontal ' + options.className +
 		(options.lineType === "dashed" ? "dashed" : "");
@@ -391,7 +397,8 @@ export function yLine(y, label, width, options = {}) {
 	return makeHoriLine(y, label, x1, x2, {
 		className: options.className,
 		lineType: options.lineType,
-		shortenNumbers: options.shortenNumbers
+		shortenNumbers: options.shortenNumbers,
+		numberFormatter: options.numberFormatter,
 	});
 }
 


### PR DESCRIPTION
You can now pass `numberFormatter` function in `axisOptions` to customize the behavior of number shortening. This is required in countries where K/M/B/T is not the standard way of shortening large numbers. E.g. India has thousands, lakh (1e5), crore (1e7).

The interface for this function is pretty simple

```javascript
(value) => {
    // format value
    return value
};
```



Outcome

<img width="1271" alt="Screenshot 2022-07-14 at 8 11 41 PM" src="https://user-images.githubusercontent.com/9079960/179011308-c1ad93d0-bb4a-4faa-94e6-22733d0b2c3d.png">
