### PR TITLE
Correct chart type key name in first example

### DIFF
--- a/docs/getting_started/quick_start.md
+++ b/docs/getting_started/quick_start.md
@@ -26,11 +26,11 @@ const data = {
     ],
     datasets: [
         {
-            name: "Some Data", type: "bar",
+            name: "Some Data", chartType: "bar",
             values: [25, 40, 30, 35, 8, 52, 17, -4]
         },
         {
-            name: "Another Set", type: "line",
+            name: "Another Set", chartType: "line",
             values: [25, 50, -10, 15, 18, 32, 27, 14]
         }
     ]


### PR DESCRIPTION
I was wondering why the `type` wasn't effective.
