### PR TITLE
fix: rollup to generate css file with proper name

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frappe-charts",
-  "version": "2.0.0-rc25",
+  "version": "2.0.0-rc26",
   "main": "dist/frappe-charts.esm.js",
   "module": "dist/frappe-charts.esm.js",
   "browser": "dist/frappe-charts.umd.js",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -24,7 +24,7 @@ export default [
 				exclude: ['node_modules/**']
 			}),
 			terser(),
-			scss({ output: 'dist/frappe-charts.min.css' }),
+			scss({ fileName: 'frappe-charts.min.css' }),
 			bundleSize()
 		]
 	},


### PR DESCRIPTION
CSS file name being generated was was output <hash.css>
It needs to be frappe-charts-min.css