### PR TITLE
fix: accomodate labels on x-axis better by displaying them diagonally when less space

### DIFF
--- a/src/js/charts/AxisChart.js
+++ b/src/js/charts/AxisChart.js
@@ -404,11 +404,7 @@ export default class AxisChart extends BaseChart {
 				},
 				function () {
 					let s = this.state;
-					s.xAxis.calcLabels = getShortenedLabels(
-						this.width,
-						s.xAxis.labels,
-						this.config.xIsSeries
-					);
+					s.xAxis.calcLabels = getShortenedLabels(s.xAxis.labels);
 
 					return s.xAxis;
 				}.bind(this),

--- a/src/js/charts/AxisChart.js
+++ b/src/js/charts/AxisChart.js
@@ -404,7 +404,11 @@ export default class AxisChart extends BaseChart {
 				},
 				function () {
 					let s = this.state;
-					s.xAxis.calcLabels = getShortenedLabels(s.xAxis.labels);
+					s.xAxis.calcLabels = getShortenedLabels(
+						this.width,
+						s.xAxis.labels,
+						this.config.xIsSeries
+					);
 
 					return s.xAxis;
 				}.bind(this),

--- a/src/js/charts/AxisChart.js
+++ b/src/js/charts/AxisChart.js
@@ -126,6 +126,7 @@ export default class AxisChart extends BaseChart {
 			positions: labels.map((d, i) =>
 				floatTwo(s.xOffset + i * s.unitWidth)
 			),
+			unitWidth: s.unitWidth,
 		};
 	}
 

--- a/src/js/objects/ChartComponents.js
+++ b/src/js/objects/ChartComponents.js
@@ -24,6 +24,7 @@ import {
 	animatePathStr,
 } from "../utils/animate";
 import { getMonthName } from "../utils/date-utils";
+import { getStringWidth } from "../utils/helpers";
 
 class ChartComponent {
 	constructor({
@@ -276,10 +277,19 @@ let componentConfigs = {
 	xAxis: {
 		layerClass: "x axis",
 		makeElements(data) {
+			const unitWidth = data.unitWidth || 0;
+			const maxLabelWidth = data.calcLabels.reduce((max, label) => {
+				const width = getStringWidth(label, 5);
+				return Math.max(max, width);
+			}, 0);
+			
+			const needsDiagonal = maxLabelWidth + 10 > unitWidth;
+			
 			return data.positions.map((position, i) =>
 				xLine(position, data.calcLabels[i], this.constants.height, {
 					mode: this.constants.mode,
 					pos: this.constants.pos,
+					useDiagonal: needsDiagonal,
 				})
 			);
 		},

--- a/src/js/objects/ChartComponents.js
+++ b/src/js/objects/ChartComponents.js
@@ -24,7 +24,7 @@ import {
 	animatePathStr,
 } from "../utils/animate";
 import { getMonthName } from "../utils/date-utils";
-import { getStringWidth } from "../utils/helpers";
+import { shouldUseDiagonalLabels } from "../utils/axis-chart-utils";
 
 class ChartComponent {
 	constructor({
@@ -278,13 +278,7 @@ let componentConfigs = {
 		layerClass: "x axis",
 		makeElements(data) {
 			const unitWidth = data.unitWidth || 0;
-			const maxLabelWidth = data.calcLabels.reduce((max, label) => {
-				const width = getStringWidth(label, 5);
-				return Math.max(max, width);
-			}, 0);
-			
-			const needsDiagonal = maxLabelWidth + 10 > unitWidth;
-			
+		const needsDiagonal = shouldUseDiagonalLabels(unitWidth, data.calcLabels);
 			return data.positions.map((position, i) =>
 				xLine(position, data.calcLabels[i], this.constants.height, {
 					mode: this.constants.mode,

--- a/src/js/utils/axis-chart-utils.js
+++ b/src/js/utils/axis-chart-utils.js
@@ -1,4 +1,4 @@
-import { fillArray } from "../utils/helpers";
+import { fillArray, getStringWidth } from "../utils/helpers";
 import {
 	DEFAULT_AXIS_CHART_TYPE,
 	AXIS_DATASET_CHART_TYPES,
@@ -107,15 +107,33 @@ export function zeroDataPrep(realData) {
 	return zeroData;
 }
 
+export function shouldUseDiagonalLabels(unitWidth, labels) {
+	if (!labels?.length) return false;
+	
+	const maxLabelWidth = labels.reduce((max, label) => {
+		const width = getStringWidth(label + "", 5);
+		return Math.max(max, width);
+	}, 0);
+	
+	return maxLabelWidth + 10 > unitWidth;
+}
+
 export function getShortenedLabels(chartWidth, labels = [], isSeries = true) {
 	let allowedSpace = (chartWidth / labels.length) * SERIES_LABEL_SPACE_RATIO;
 	if (allowedSpace <= 0) allowedSpace = 1;
-	const allowedLetters = allowedSpace / DEFAULT_CHAR_WIDTH;
+	
+	const unitWidth = chartWidth / labels.length;
+	const needsDiagonal = shouldUseDiagonalLabels(unitWidth, labels);
+	
+	const spaceFactor = needsDiagonal ? 2 : 1;
+	const effectiveAllowedSpace = allowedSpace * spaceFactor;
+	const allowedLetters = effectiveAllowedSpace / DEFAULT_CHAR_WIDTH;
 	
 	let skipFactor = 1;
 	if (isSeries || labels.length > 15) {
 		const maxLength = Math.max(...labels.map(l => (l + "").length));
-		skipFactor = Math.max(1, Math.ceil(maxLength / allowedLetters / 2));
+		const divisor = needsDiagonal ? 3 : 2;
+		skipFactor = Math.max(1, Math.ceil(maxLength / allowedLetters / divisor));
 	}
 	
 	const calcLabels = labels.map((label, i) => {

--- a/src/js/utils/axis-chart-utils.js
+++ b/src/js/utils/axis-chart-utils.js
@@ -130,7 +130,7 @@ export function getShortenedLabels(chartWidth, labels = [], isSeries = true) {
 	const allowedLetters = effectiveAllowedSpace / DEFAULT_CHAR_WIDTH;
 	
 	let skipFactor = 1;
-	if (isSeries || labels.length > 15) {
+	if (isSeries || labels.length > 15 || needsDiagonal) {
 		const maxLength = Math.max(...labels.map(l => (l + "").length));
 		const divisor = needsDiagonal ? 3 : 2;
 		skipFactor = Math.max(1, Math.ceil(maxLength / allowedLetters / divisor));
@@ -139,7 +139,7 @@ export function getShortenedLabels(chartWidth, labels = [], isSeries = true) {
 	const calcLabels = labels.map((label, i) => {
 		label += "";
 		
-		if (skipFactor > 1 && i % skipFactor !== 0 && i !== labels.length - 1) {
+		if (skipFactor > 1 && i % skipFactor !== 0) {
 			return "";
 		}
 		

--- a/src/js/utils/axis-chart-utils.js
+++ b/src/js/utils/axis-chart-utils.js
@@ -4,6 +4,7 @@ import {
 	AXIS_DATASET_CHART_TYPES,
 	DEFAULT_CHAR_WIDTH,
 	SERIES_LABEL_SPACE_RATIO,
+	MAX_LABEL_LENGTH,
 } from "../utils/constants";
 
 export function dataPrep(data, type, config) {
@@ -106,14 +107,28 @@ export function zeroDataPrep(realData) {
 	return zeroData;
 }
 
-export function getShortenedLabels(labels = []) {
-	const MAX_LABEL_LENGTH = 20;
+export function getShortenedLabels(chartWidth, labels = [], isSeries = true) {
+	let allowedSpace = (chartWidth / labels.length) * SERIES_LABEL_SPACE_RATIO;
+	if (allowedSpace <= 0) allowedSpace = 1;
+	const allowedLetters = allowedSpace / DEFAULT_CHAR_WIDTH;
 	
-	const calcLabels = labels.map((label) => {
+	let skipFactor = 1;
+	if (isSeries || labels.length > 15) {
+		const maxLength = Math.max(...labels.map(l => (l + "").length));
+		skipFactor = Math.max(1, Math.ceil(maxLength / allowedLetters / 2));
+	}
+	
+	const calcLabels = labels.map((label, i) => {
 		label += "";
+		
+		if (skipFactor > 1 && i % skipFactor !== 0 && i !== labels.length - 1) {
+			return "";
+		}
+		
 		if (label.length > MAX_LABEL_LENGTH) {
 			label = label.slice(0, MAX_LABEL_LENGTH - 3) + "...";
 		}
+		
 		return label;
 	});
 

--- a/src/js/utils/axis-chart-utils.js
+++ b/src/js/utils/axis-chart-utils.js
@@ -106,32 +106,13 @@ export function zeroDataPrep(realData) {
 	return zeroData;
 }
 
-export function getShortenedLabels(chartWidth, labels = [], isSeries = true) {
-	let allowedSpace = (chartWidth / labels.length) * SERIES_LABEL_SPACE_RATIO;
-	if (allowedSpace <= 0) allowedSpace = 1;
-	let allowedLetters = allowedSpace / DEFAULT_CHAR_WIDTH;
-
-	let seriesMultiple;
-	if (isSeries) {
-		// Find the maximum label length for spacing calculations
-		let maxLabelLength = Math.max(...labels.map((label) => label.length));
-		seriesMultiple = Math.ceil(maxLabelLength / allowedLetters);
-	}
-
-	let calcLabels = labels.map((label, i) => {
+export function getShortenedLabels(labels = []) {
+	const MAX_LABEL_LENGTH = 20;
+	
+	const calcLabels = labels.map((label) => {
 		label += "";
-		if (label.length > allowedLetters) {
-			if (!isSeries) {
-				if (allowedLetters - 3 > 0) {
-					label = label.slice(0, allowedLetters - 3) + " ...";
-				} else {
-					label = label.slice(0, allowedLetters) + "..";
-				}
-			} else {
-				if (i % seriesMultiple !== 0 && i !== labels.length - 1) {
-					label = "";
-				}
-			}
+		if (label.length > MAX_LABEL_LENGTH) {
+			label = label.slice(0, MAX_LABEL_LENGTH - 3) + "...";
 		}
 		return label;
 	});

--- a/src/js/utils/constants.js
+++ b/src/js/utils/constants.js
@@ -26,7 +26,7 @@ export const DATA_COLOR_DIVISIONS = {
 export const BASE_MEASURES = {
   margins: {
     top: 10,
-    bottom: 10,
+    bottom: 60,
     left: 20,
     right: 20,
   },
@@ -37,7 +37,7 @@ export const BASE_MEASURES = {
     right: 10,
   },
 
-  baseHeight: 240,
+  baseHeight: 300,
   titleHeight: 20,
   legendHeight: 30,
 

--- a/src/js/utils/constants.js
+++ b/src/js/utils/constants.js
@@ -95,7 +95,7 @@ export const HEATMAP_SQUARE_SIZE = 10;
 export const HEATMAP_GUTTER_SIZE = 2;
 
 export const DEFAULT_CHAR_WIDTH = 7;
-
+export const MAX_LABEL_LENGTH = 20;
 export const TOOLTIP_POINTER_TRIANGLE_HEIGHT = 7.48;
 const DEFAULT_CHART_COLORS = [
   "pink",

--- a/src/js/utils/draw.js
+++ b/src/js/utils/draw.js
@@ -399,7 +399,7 @@ export function makeText(className, x, y, content, options = {}) {
 
 function makeVertLine(x, label, y1, y2, options = {}) {
 	if (!options.stroke) options.stroke = BASE_LINE_COLOR;
-	let l = createSVG("line", {
+	const l = createSVG("line", {
 		className: "line-vertical " + options.className,
 		x1: 0,
 		x2: 0,
@@ -410,16 +410,18 @@ function makeVertLine(x, label, y1, y2, options = {}) {
 		},
 	});
 
-	let text = createSVG("text", {
+	const textY = y1 > y2 ? y1 + LABEL_MARGIN : y1 - LABEL_MARGIN - FONT_SIZE;
+	const text = createSVG("text", {
 		x: 0,
-		y: y1 > y2 ? y1 + LABEL_MARGIN : y1 - LABEL_MARGIN - FONT_SIZE,
+		y: textY,
 		dy: FONT_SIZE + "px",
 		"font-size": FONT_SIZE + "px",
-		"text-anchor": "middle",
+		"text-anchor": "end",
+		transform: `rotate(-45, 0, ${textY})`,
 		innerHTML: label + "",
 	});
 
-	let line = createSVG("g", {
+	const line = createSVG("g", {
 		transform: `translate(${x}, 0)`,
 	});
 

--- a/src/js/utils/draw.js
+++ b/src/js/utils/draw.js
@@ -411,15 +411,22 @@ function makeVertLine(x, label, y1, y2, options = {}) {
 	});
 
 	const textY = y1 > y2 ? y1 + LABEL_MARGIN : y1 - LABEL_MARGIN - FONT_SIZE;
-	const text = createSVG("text", {
+	const textAttrs = {
 		x: 0,
 		y: textY,
 		dy: FONT_SIZE + "px",
 		"font-size": FONT_SIZE + "px",
-		"text-anchor": "end",
-		transform: `rotate(-45, 0, ${textY})`,
 		innerHTML: label + "",
-	});
+	};
+	
+	if (options.useDiagonal) {
+		textAttrs["text-anchor"] = "end";
+		textAttrs.transform = `rotate(-45, 0, ${textY})`;
+	} else {
+		textAttrs["text-anchor"] = "middle";
+	}
+	
+	const text = createSVG("text", textAttrs);
 
 	const line = createSVG("g", {
 		transform: `translate(${x}, 0)`,
@@ -598,6 +605,7 @@ export function xLine(x, label, height, options = {}) {
 	return makeVertLine(x, label, y1, y2, {
 		stroke: options.stroke,
 		className: options.className,
+		useDiagonal: options.useDiagonal,
 		lineType: options.lineType,
 	});
 }


### PR DESCRIPTION
Based on: https://github.com/frappe/frappe/issues/16878

#### Changes

- Don't increase label truncation on reducing chart width
- Display labels diagonally in case of insufficient horizontal space (allows fitting more labels in series charts)
- Skip labels for non-series charts as well to avoid text overlap
- Don't force last label (leads to overlap)

#### Before

https://github.com/user-attachments/assets/e40725e6-0dff-46f8-a3c2-b39ea5543429

#### After

https://github.com/user-attachments/assets/d4118a99-89ce-400b-832a-449426d72dcd



