### PR TITLE
fix: use axis number formatter for values over points

### DIFF
--- a/src/js/charts/AxisChart.js
+++ b/src/js/charts/AxisChart.js
@@ -193,6 +193,12 @@ export default class AxisChart extends BaseChart {
 		return [].concat(...allValueLists);
 	}
 
+	formatValueLabel(value) {
+		return this.config.numberFormatter
+			? this.config.numberFormatter(value)
+			: shortenLargeNumber(value);
+	}
+
 	setupComponents() {
 		let componentConfigs = [
 			[
@@ -268,11 +274,9 @@ export default class AxisChart extends BaseChart {
 
 					let labels = new Array(s.datasetLength).fill('');
 					if (this.config.valuesOverPoints) {
-						if (stacked && d.index === s.datasets.length - 1) {
-							labels = d.cumulativeYs;
-						} else {
-							labels = d.values.map(v => shortenLargeNumber(v));
-						}
+						let values = stacked && d.index === s.datasets.length - 1
+							? d.cumulativeYs : d.values;
+						labels = values.map(v => this.formatValueLabel(v));
 					}
 
 					let offsets = new Array(s.datasetLength).fill(0);


### PR DESCRIPTION
Y-axis labels honour `axisOptions.numberFormatter`, but the values drawn over bars do not; they call `shortenLargeNumber` directly, which has a hardcoded `K/M/B/T` suffix table. On any chart that passes a formatter, the two disagree.

Frappe hits this on every dashboard chart with "Show Values Over Chart" enabled on an Indian-locale site. `frappe.utils.make_chart` passes a formatter that returns the Indian number system, so the axis reads `6 Cr` while the bar labels on the same chart read `56M`. Same numbers, two unit systems, one chart.

Routing the value labels through the configured formatter fixes it. The stacked branch is folded into the same path; it was passing `cumulativeYs` through unformatted, so stacked totals printed in full while the axis was shortened. Charts that pass no formatter keep the existing `shortenLargeNumber` output, so nothing changes for anyone not setting one.